### PR TITLE
Minor README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ What is it?
 ``ocicl`` is a modern alternative to quicklisp.  It is modern in the sense that:
 * all software is [bundled as OCI-compliant artifacts](https://oras.land/) and distributed from an OCI-compliant registry (the github container registry).
 * all software is distributed over secure (TLS) connections.
-* [sigstore](https://www.sigstore.dev/) tooling is used ensure the integrity and authenticity of all software bundles.
+* [sigstore](https://www.sigstore.dev/) tooling is used to ensure the integrity and authenticity of all software bundles.
 * all software bundles are project-local, making it easy to lock specific versions to your own projects.
 * all software bundles are built and published transparently using hosted CI infrastructure ([github actions](https://github.com/ocicl/ocicl-action)).
 
-``ocicl`` rhymes with
+``ocicl`` is pronounced like
 "[ossicle](https://en.wikipedia.org/wiki/Ossicles)", a tiny bone
 embedded in your middle ear.  Like the ossicles in your ear, the
 ``ocicl-runtime`` is a tiny library that is embedded in your lisp

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -124,7 +124,7 @@ Distributed under the terms of the MIT License"
                             :direction :output
                             :if-exists :supersede)
       (write-string +runtime+ stream)
-      (format t "Add the following to your ${HOME}/.sbclrc file:~%~%#-ocicl~%(when (probe-file ~S)~%  (load ~S))~%~%" runtime-source runtime-source))))
+      (format t "; Add the following to your ${HOME}/.sbclrc file:~%~%#-ocicl~%(when (probe-file ~S)~%  (load ~S))~%~%" runtime-source runtime-source))))
 
 (defun do-install (args)
   ;; Make sure the systems directory exists

--- a/runtime/ocicl-runtime.lisp
+++ b/runtime/ocicl-runtime.lisp
@@ -63,6 +63,7 @@
 (defun ocicl-install (name)
   (let* ((cmd (format nil "ocicl install ~A" name))
          (output (uiop:run-program cmd :output '(:string))))
+    (setq *systems-csv-mtime* 0)
     (when *verbose*
       (format t "~A~%~A~%" cmd output))))
 

--- a/runtime/ocicl-runtime.lisp
+++ b/runtime/ocicl-runtime.lisp
@@ -77,7 +77,7 @@
     (let ((mtime (sb-posix:stat-mtime (sb-posix:stat *systems-csv*))))
       (when (> mtime *systems-csv-mtime*)
         (when *verbose*
-          (format t "; old csv mtime = ~A~%; new csv mtime = ~A~%" mtime))
+          (format t "; old csv mtime = ~A~%; new csv mtime = ~A~%" *systems-csv-mtime* mtime))
         (setq *ocicl-systems* (read-systems-csv))
         (setq *systems-csv-mtime* mtime))))
 

--- a/runtime/ocicl-runtime.lisp
+++ b/runtime/ocicl-runtime.lisp
@@ -76,6 +76,8 @@
   (when (probe-file *systems-csv*)
     (let ((mtime (sb-posix:stat-mtime (sb-posix:stat *systems-csv*))))
       (when (> mtime *systems-csv-mtime*)
+        (when *verbose*
+          (format t "; old csv mtime = ~A~%; new csv mtime = ~A~%" mtime))
         (setq *ocicl-systems* (read-systems-csv))
         (setq *systems-csv-mtime* mtime))))
 


### PR DESCRIPTION
Add missing "to", plus I think you meant to say that "ocicl" is pronounced like "ossicle" rather than that they rhyme?